### PR TITLE
Add title to the swagger file

### DIFF
--- a/schema/index.yaml
+++ b/schema/index.yaml
@@ -2,6 +2,7 @@
 # Licensed under the terms of the New-BSD license. Please see LICENSE file in the project root for terms.
 
 swagger: '2.0'
+title: 'Flickr API'
 info:
   $ref: ./info/index.yaml
 basePath: /services

--- a/schema/index.yaml
+++ b/schema/index.yaml
@@ -2,9 +2,9 @@
 # Licensed under the terms of the New-BSD license. Please see LICENSE file in the project root for terms.
 
 swagger: '2.0'
-title: 'Flickr API'
 info:
   $ref: ./info/index.yaml
+  title: 'Flickr API'
 basePath: /services
 host: api.flickr.com
 schemes:


### PR DESCRIPTION
The field `title` is mandatory according to the swagger 2.0 spec.
Source: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md